### PR TITLE
Improve type definitions in common_2008

### DIFF
--- a/rtl/extras_2008/common_2008.vhdl
+++ b/rtl/extras_2008/common_2008.vhdl
@@ -38,6 +38,29 @@
 --#  VHDL-2008 syntax. This provides a common set of types and conversion
 --#  functions that can be used to interoperate between different library
 --#  components that need to make use of fully unconstrained types.
+--#
+--#  Note, that VHDL-2008 introduced new syntax for resolved subtypes, so now
+--#  a resolution function for an element type can be applied to an array of
+--#  that type. Thanks to this, std_logic_vector in VHDL-2008 is a resolved
+--#  subtype of std_ulogic_vector, and not a separate type, as it used to be in
+--#  the previous version of the language. Because of this, slv and sulv can be
+--#  assigned to each other freely, and no separate function overloads are
+--#  required for them now. The same applies to unresolved_signed and signed,
+--#  and to unresolved_unsigned and unsigned.
+--#  This package uses the same approach. For example, any function here
+--#  defined for sulv_array can take slv_array. The same applies to
+--#  u_unsigned_array and unsigned_array, and to u_signed_array and
+--#  signed_array.
+--#
+--#  Also note, that the types defined here are closely related (see 9.3.6 in
+--#  LRM). So, one can convert between them using regular VHDL type conversion:
+--#   constant c : sulv_array := ("000", "010");
+--#   signal s : u_signed_array(c'range)(c'element'range);
+--#   ...
+--#   s <= u_signed_array(c); -- Regular type conversion
+--#  However, not every synthesis tool supports it. Because of this, explicit
+--#  type conversion functions are defined in this package (to_sulv_array, ...
+--#  to_u_unsigned_array, etc.).
 --------------------------------------------------------------------
 
 library ieee;
@@ -50,103 +73,21 @@ package common is
   type sulv_array is array(natural range <>) of std_ulogic_vector;
 
   --## Array of std_logic_vector.
-  type slv_array  is array(natural range <>) of std_logic_vector;
+  subtype slv_array is ((resolved)) sulv_array;
 
-  --## Array of unsigned.
-  type unsigned_array is array(natural range <>) of unsigned;
-  
-  --## Array of signed.
-  type signed_array   is array(natural range <>) of signed;
-  
   --## Array of unresolved_unsigned.
   type u_unsigned_array is array(natural range <>) of u_unsigned;
-  
+
+  --## Array of unsigned.
+  subtype unsigned_array is ((resolved)) u_unsigned_array;
+
   --## Array of unresolved_signed.
   type u_signed_array   is array(natural range <>) of u_signed;
 
-  --## Convert std_ulogic_vector array to std_logic_vector array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_slv_array(A : sulv_array) return slv_array;
-  
-  --## Convert std_logic_vector array to std_ulogic_vector array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_sulv_array(A : slv_array) return sulv_array;
+  --## Array of signed.
+  subtype signed_array is ((resolved)) u_signed_array;
 
-  --## Convert std_ulogic_vector array to unsigned array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_unsigned_array(A : sulv_array) return unsigned_array;
-  
-  --## Convert unsigned array to std_ulogic_vector array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_sulv_array(A : unsigned_array) return sulv_array;
 
-  --## Convert std_ulogic_vector array to signed array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_signed_array(A : sulv_array) return signed_array;
-  
-  --## Convert signed array to std_ulogic_vector array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_sulv_array(A : signed_array) return sulv_array;
-
-  --## Convert std_logic_vector array to unsigned array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_unsigned_array(A : slv_array) return unsigned_array;
-
-  --## Convert unsigned array to std_logic_vector array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_slv_array(A : unsigned_array) return slv_array;
-
-  --## Convert std_logic_vector array to signed array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_signed_array(A : slv_array) return signed_array;
-  
-  --## Convert signed array to std_logic_vector array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_slv_array(A : signed_array) return slv_array;
-
-  --## Convert unsigned array to signed array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_signed_array(A : unsigned_array) return signed_array;
-
-  --## Convert signed array to unsigned array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_unsigned_array(A : signed_array) return unsigned_array;
 
   --## Convert std_ulogic_vector array to unresolved_unsigned array.
   --# Args:
@@ -161,48 +102,6 @@ package common is
   --# Returns:
   --#  Array with new type.
   function to_sulv_array(A : u_unsigned_array) return sulv_array;
-
-  --## Convert std_logic_vector array to unresolved_unsigned array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_u_unsigned_array(A : slv_array) return u_unsigned_array;
-  
-  --## Convert unresolved_unsigned array to std_logic_vector array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_slv_array(A : u_unsigned_array) return slv_array;
-
-  --## Convert unsigned array to unresolved_unsigned array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_u_unsigned_array(A : unsigned_array) return u_unsigned_array;
-  
-  --## Convert unresolved_unsigned array to unsigned array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_unsigned_array(A : u_unsigned_array) return unsigned_array;
-
-  --## Convert signed array to unresolved_unsigned array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_u_unsigned_array(A : signed_array) return u_unsigned_array;
-  
-  --## Convert unresolved_unsigned array to signed array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_signed_array(A : u_unsigned_array) return signed_array;
 
   --## Convert unresolved_signed array to unresolved_unsigned array.
   --# Args:
@@ -232,47 +131,15 @@ package common is
   --#  Array with new type.
   function to_sulv_array(A : u_signed_array) return sulv_array;
 
-  --## Convert std_logic_vector array to unresolved_signed array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_u_signed_array(A : slv_array) return u_signed_array;
-  
-  --## Convert unresolved_signed array to std_logic_vector array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_slv_array(A : u_signed_array) return slv_array;
+  --## Aliases without u_* prefix for convenience
+  alias to_unsigned_array is to_u_unsigned_array[sulv_array     return u_unsigned_array];
+  alias to_unsigned_array is to_u_unsigned_array[u_signed_array return u_unsigned_array];
 
-  --## Convert unsigned array to unresolved_signed array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_u_signed_array(A : unsigned_array) return u_signed_array;
-  
-  --## Convert signed array to unsigned array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_unsigned_array(A : u_signed_array) return unsigned_array;
+  alias to_slv_array is to_sulv_array[u_unsigned_array return sulv_array];
+  alias to_slv_array is to_sulv_array[u_signed_array   return sulv_array];
 
-  --## Convert signed array to unresolved_signed array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_u_signed_array(A : signed_array) return u_signed_array;
-  
-  --## Convert unresolved_signed array to signed array.
-  --# Args:
-  --#  A: Array to convert
-  --# Returns:
-  --#  Array with new type.
-  function to_signed_array(A : u_signed_array) return signed_array;
+  alias to_signed_array is to_u_signed_array[u_unsigned_array return u_signed_array];
+  alias to_signed_array is to_u_signed_array[sulv_array       return u_signed_array];
 
 
 
@@ -282,27 +149,6 @@ package common is
   --# Returns:
   --#  Array with new type.
   function to_sulv_array(A : std_ulogic_vector) return sulv_array;
-
-  --## Convert a scaler std_logic_vector to a single element std_logic_vector array.
-  --# Args:
-  --#  A: Vector
-  --# Returns:
-  --#  Array with new type.
-  function to_slv_array(A : std_logic_vector) return slv_array;
-
-  --## Convert a scaler unsigned to a single element unsigned array.
-  --# Args:
-  --#  A: Vector
-  --# Returns:
-  --#  Array with new type.
-  function to_unsigned_array(A : unsigned) return unsigned_array;
-  
-  --## Convert a scaler signed to a single element signed array.
-  --# Args:
-  --#  A: Vector
-  --# Returns:
-  --#  Array with new type.
-  function to_signed_array(A : signed) return signed_array;
   
   --## Convert a scaler unresolved_unsigned to a single element unresolved_unsigned array.
   --# Args:
@@ -318,129 +164,14 @@ package common is
   --#  Array with new type.  
   function to_u_signed_array(A : u_signed) return u_signed_array;
 
+  --## Aliases without u_* prefix for convenience
+  alias to_slv_array is to_sulv_array[std_ulogic_vector return sulv_array];
+  alias to_unsigned_array is to_u_unsigned_array[u_unsigned return u_unsigned_array];
+  alias to_signed_array is to_u_signed_array[u_signed return u_signed_array];
+
 end package;
 
 package body common is
-
-  function to_slv_array(a : sulv_array) return slv_array is
-    variable r : slv_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := a(i);
-    end loop;
-    return r;
-  end function;
-
-  function to_sulv_array(a : slv_array) return sulv_array is
-    variable r : sulv_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := a(i);
-    end loop;
-    return r;
-  end function;
-
-
-
-  function to_unsigned_array(a : sulv_array) return unsigned_array is
-    variable r : unsigned_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := unsigned(a(i));
-    end loop;
-    return r;
-  end function;
-
-  function to_sulv_array(a : unsigned_array) return sulv_array is
-    variable r : sulv_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := std_ulogic_vector(a(i));
-    end loop;
-    return r;
-  end function;
-
-
-
-  function to_signed_array(a : sulv_array) return signed_array is
-    variable r : signed_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := signed(a(i));
-    end loop;
-    return r;
-  end function;
-
-  function to_sulv_array(a : signed_array) return sulv_array is
-    variable r : sulv_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := std_ulogic_vector(a(i));
-    end loop;
-    return r;
-  end function;
-
-
-
-  function to_unsigned_array(a : slv_array) return unsigned_array is
-    variable r : unsigned_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := unsigned(a(i));
-    end loop;
-    return r;
-  end function;
-
-  function to_slv_array(a : unsigned_array) return slv_array is
-    variable r : slv_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := std_logic_vector(a(i));
-    end loop;
-    return r;
-  end function;
-
-
-
-  function to_signed_array(a : slv_array) return signed_array is
-    variable r : signed_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := signed(a(i));
-    end loop;
-    return r;
-  end function;
-
-  function to_slv_array(a : signed_array) return slv_array is
-    variable r : slv_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := std_logic_vector(a(i));
-    end loop;
-    return r;
-  end function;
-
-
-
-  function to_signed_array(a : unsigned_array) return signed_array is
-    variable r : signed_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := signed(a(i));
-    end loop;
-    return r;
-  end function;
-
-  function to_unsigned_array(a : signed_array) return unsigned_array is
-    variable r : unsigned_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := unsigned(a(i));
-    end loop;
-    return r;
-  end function;
-
-
 
   function to_u_unsigned_array(a : sulv_array) return u_unsigned_array is
     variable r : u_unsigned_array(a'range)(a'element'range);
@@ -460,68 +191,6 @@ package body common is
     return r;
   end function;
 
-
-
-  function to_u_unsigned_array(a : slv_array) return u_unsigned_array is
-    variable r : u_unsigned_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := u_unsigned(a(i));
-    end loop;
-    return r;
-  end function;
-
-  function to_slv_array(a : u_unsigned_array) return slv_array is
-      variable r : slv_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := std_logic_vector(a(i));
-    end loop;
-    return r;
-  end function;
-
-
-
-  function to_u_unsigned_array(a : unsigned_array) return u_unsigned_array is
-    variable r : u_unsigned_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := a(i);
-    end loop;
-    return r;
-  end function;
-
-  function to_unsigned_array(a : u_unsigned_array) return unsigned_array is
-    variable r : unsigned_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := a(i);
-    end loop;
-    return r;
-  end function;
-
-
-
-  function to_u_unsigned_array(a : signed_array) return u_unsigned_array is
-    variable r : u_unsigned_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := u_unsigned(a(i));
-    end loop;
-    return r;
-  end function;
-
-  function to_signed_array(a : u_unsigned_array) return signed_array is
-    variable r : signed_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := signed(a(i));
-    end loop;
-    return r;
-  end function;
-
-
-
   function to_u_unsigned_array(a : u_signed_array) return u_unsigned_array is
     variable r : u_unsigned_array(a'range)(a'element'range);
   begin
@@ -539,8 +208,6 @@ package body common is
     end loop;
     return r;
   end function;
-
-
 
   function to_u_signed_array(a : sulv_array) return u_signed_array is
     variable r : u_signed_array(a'range)(a'element'range);
@@ -562,89 +229,8 @@ package body common is
 
 
 
-  function to_u_signed_array(a : slv_array) return u_signed_array is
-    variable r : u_signed_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := u_signed(a(i));
-    end loop;
-    return r;
-  end function;
-
-  function to_slv_array(a : u_signed_array) return slv_array is
-    variable r : slv_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := std_logic_vector(a(i));
-    end loop;
-    return r;
-  end function;
-
-
-
-  function to_u_signed_array(a : unsigned_array) return u_signed_array is
-    variable r : u_signed_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := u_signed(a(i));
-    end loop;
-    return r;
-  end function;
-
-  function to_unsigned_array(a : u_signed_array) return unsigned_array is
-    variable r : unsigned_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := unsigned(a(i));
-    end loop;
-    return r;
-  end function;
-
-
-
-  function to_u_signed_array(a : signed_array) return u_signed_array is
-    variable r : u_signed_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := a(i);
-    end loop;
-    return r;
-  end function;
-
-  function to_signed_array(a : u_signed_array) return signed_array is
-    variable r : signed_array(a'range)(a'element'range);
-  begin
-    for i in a'range loop
-      r(i) := a(i);
-    end loop;
-    return r;
-  end function;
-
-
-
   function to_sulv_array(a : std_ulogic_vector) return sulv_array is
     variable r : sulv_array(0 downto 0)(a'range);
-  begin
-    r(0) := a;
-    return r;
-  end function;
-
-  function to_slv_array(a : std_logic_vector) return slv_array is
-    variable r : slv_array(0 downto 0)(a'range);
-  begin
-    r(0) := a;
-    return r;
-  end function;
-
-  function to_unsigned_array(a : unsigned) return unsigned_array is
-    variable r : unsigned_array(0 downto 0)(a'range);
-  begin
-    r(0) := a;
-    return r;
-  end function;
-
-  function to_signed_array(a : signed) return signed_array is
-    variable r : signed_array(0 downto 0)(a'range);
   begin
     r(0) := a;
     return r;
@@ -665,5 +251,3 @@ package body common is
   end function;
 
 end package body;
-
-


### PR DESCRIPTION
This PR redefines resolved arrays as subtypes of the unresolved ones (VHDL-2008 feature). This greatly simplifies type conversions reducing the number of the required functions overloads.
The more detailed explanation is in "DESCRIPTION" section of common_2008.vhdl