### PR TITLE
Make change_size function safer (sizing_2008)

### DIFF
--- a/rtl/extras_2008/sizing_2008.vhdl
+++ b/rtl/extras_2008/sizing_2008.vhdl
@@ -50,6 +50,8 @@
 --#  Additionally the package provides functions for vectors resizing with
 --#  interfaces which show clearly, how resizing should be performed (extending
 --#  or truncating, most significant bits or least significant bits).
+--#  The leftmost bit is treated as the most significant bit (like in
+--#  NUMERIC_STD).
 --#
 --#  This implementation excludes the overload of change_size for resolved
 --#  std_logic_vector, because it breaks VHDL-2008 compiler (slv and sulv are
@@ -141,7 +143,8 @@ package sizing is
   
   type resize_method is (truncate_LSBs, truncate_MSBs, extend_LSBs, extend_MSBs);
   --## Resizizng function for std_ulogic_vector clearly stating how exactly the 
-  --# resizing will be done.
+  --# resizing will be done. The leftmost bit is treated as the most significant
+  --# bit (like in NUMERIC_STD).
   --#
   --# Args:
   --#   s: Vector to  resize
@@ -154,7 +157,8 @@ package sizing is
     extension : std_ulogic := '0' ) return std_ulogic_vector;
     
   --## Resizizng function for unsigned number clearly stating how exactly the 
-  --# resizing will be done. Extends numbers with zeros.
+  --# resizing will be done. Extends numbers with zeros. The leftmost bit is
+  --# treated as the most significant bit (like in NUMERIC_STD).
   --#
   --# Args:
   --#   s: Vector to  resize
@@ -167,7 +171,8 @@ package sizing is
     
   --## Resizizng function for signed number clearly stating how exactly the 
   --# resizing will be done. Extends most significant bits with a sign bit,
-  --# and least significant bits with zeros.
+  --# and least significant bits with zeros. The leftmost bit is treated as the
+  --# most significant bit (like in NUMERIC_STD).
   --#
   --# Args:
   --#   s: Vector to  resize
@@ -279,7 +284,8 @@ package body sizing is
   end function;
 
   --## Resizizng function for std_ulogic_vector clearly stating how exactly the 
-  --# resizing will be done.
+  --# resizing will be done. The leftmost bit is treated as the most significant
+  --# bit (like in NUMERIC_STD).
   function change_size (s : std_ulogic_vector; new_size : positive; method : resize_method;
       extension : std_ulogic := '0' ) return std_ulogic_vector is
     
@@ -329,7 +335,8 @@ package body sizing is
   end function;
   
   --## Resizizng function for unsigned number clearly stating how exactly the 
-  --# resizing will be done. Extends numbers with zeros.
+  --# resizing will be done. Extends numbers with zeros. The leftmost bit is
+  --# treated as the most significant bit (like in NUMERIC_STD).
   function change_size (s : u_unsigned; new_size : positive; method : resize_method)
     return u_unsigned is
   begin
@@ -339,7 +346,8 @@ package body sizing is
   
   --## Resizizng function for signed number clearly stating how exactly the 
   --# resizing will be done. Extends most significant bits with a sign bit,
-  --# and least significant bits with zeros.
+  --# and least significant bits with zeros. The leftmost bit is treated as the
+  --# most significant bit (like in NUMERIC_STD).
   function change_size (s : u_signed; new_size : positive; method : resize_method)
     return u_signed is
   begin


### PR DESCRIPTION
Changes to `change_size` in this PR:
- allow an input vector to have any bits direction (`downto` and `to`);
- add checks preventing an ill-formed resize operation;
- clarify MSB position in change_size (in comments).

However, there's a small problem with it. Line 299 now may cause a compilation warning (null range). The purpose of this line is to trigger a compilation error at synthesis stage (line 305) even if a synthesis tool ignored the `assert` on line 304. As a bonus, the error will be triggered on the line with the erroneous user's code, and not in sizing_2008.vhdl.
If you know a way of avoiding the warning, please, let me know.

I was also thinking about moving the `change_size` functions into a separate file. Their purpose seems now to be too far from the other functions in sizing_2008. It was probably a mistake from me to add these functions in this file. Please, let me know what you think.